### PR TITLE
Automatically monkeypatch `puts` to capture output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Added
 - Support logging multiple printed outputs
+- Automatically monkeypatch `puts` to capture output
 
 ## v0.4.0 (2021-02-04)
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,16 +62,6 @@ $ gem specific_install davidrunger/living_document
 Put this content into a file called `personal/ruby.rb`:
 
 ```rb
-# frozen_string_literal: true
-
-# rubocop:disable Lint/MissingCopEnableDirective,  Lint/RedundantCopDisableDirective, Lint/Void
-
-def puts(printed_value)
-  $printed_objects << printed_value
-end
-
-############
-
 1 + 2
 ###
 
@@ -92,16 +82,6 @@ Then go back to `personal/ruby.rb` in your editor and save the file. It should b
 this:
 
 ```rb
-# frozen_string_literal: true
-
-# rubocop:disable Lint/MissingCopEnableDirective,  Lint/RedundantCopDisableDirective, Lint/Void
-
-def puts(printed_value)
-  $printed_objects << printed_value
-end
-
-############
-
 1 + 2
 # => 3
 

--- a/lib/living_document/capturing_string_i_o.rb
+++ b/lib/living_document/capturing_string_i_o.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class LivingDocument::CapturingStringIO < StringIO
+  def puts(*printed_values)
+    $printed_objects += printed_values
+  end
+end

--- a/spec/living_document/code_evaluator_spec.rb
+++ b/spec/living_document/code_evaluator_spec.rb
@@ -4,163 +4,174 @@ require 'spec_helper'
 
 RSpec.describe LivingDocument::CodeEvaluator do
   subject(:code_evaluator) do
-    LivingDocument::CodeEvaluator.new(
-      code: code,
-      frontmatter: frontmatter,
-    )
+    LivingDocument::CodeEvaluator.new(code: code, frontmatter: '')
   end
 
   describe '#evaluated_code' do
     subject(:evaluated_code) { code_evaluator.evaluated_code }
 
-    context 'when the `frontmatter` is an empty string' do
-      let(:frontmatter) { '' }
-
-      context 'when the `code` has a `###` evaluation marker' do
-        let(:code) do
-          <<~RUBY
-            a = 1
-            b = 2
-            a + b
-            ###
-          RUBY
-        end
-
-        let(:expected_evaluated_code) do
-          <<~RUBY
-            a = 1
-            b = 2
-            a + b
-            # => 3
-          RUBY
-        end
-
-        specify { expect(evaluated_code).to eq(expected_evaluated_code) }
-
-        it 'does not modify the original code string/object' do
-          expect(code).to include('###')
-        end
-      end
-
-      context 'when there are multiple code segments marked for evaluation' do
-        let(:code) do
-          <<~RUBY
-            1 + 2
-            ###
-
-            4 / 0
-            ###
-
-            99 - 66
-            ###
-          RUBY
-        end
-
-        let(:expected_evaluated_code) do
-          <<~RUBY
-            1 + 2
-            # => 3
-
-            4 / 0
-            # => raises ZeroDivisionError
-
-            99 - 66
-            # => 33
-          RUBY
-        end
-
-        it 'evaluates them all' do
-          expect(evaluated_code).to eq(expected_evaluated_code)
-        end
-      end
-
-      context 'when the `code` has a `# =>` evaluation marker' do
-        let(:code) do
-          <<~RUBY
-            a = 2
-            b = 3
-            a + b
-            # => 3
-          RUBY
-        end
-
-        let(:expected_evaluated_code) do
-          <<~RUBY
-            a = 2
-            b = 3
-            a + b
-            # => 5
-          RUBY
-        end
-
-        specify { expect(evaluated_code).to eq(expected_evaluated_code) }
-      end
-
-      context 'when the code raises an error' do
-        let(:code) do
-          <<~RUBY
-            3 / 0
-            ###
-          RUBY
-        end
-
-        let(:expected_evaluated_code) do
-          <<~RUBY
-            3 / 0
-            # => raises ZeroDivisionError
-          RUBY
-        end
-
-        specify { expect(evaluated_code).to eq(expected_evaluated_code) }
-      end
-    end
-
-    context 'when the `frontmatter` is code to capture output from `puts`' do
-      let(:frontmatter) do
+    context 'when the `code` has a `###` evaluation marker' do
+      let(:code) do
         <<~RUBY
-          def puts(printed_value)
-            $printed_objects << printed_value
-          end
+          a = 1
+          b = 2
+          a + b
+          ###
         RUBY
       end
 
-      context 'when the `code` prints something via `puts`' do
-        let(:code) do
-          <<~RUBY
-            puts('Hello testing world!')
-            ###
-          RUBY
-        end
-
-        let(:expected_evaluated_code) do
-          <<~RUBY
-            puts('Hello testing world!')
-            # => prints "Hello testing world!"
-          RUBY
-        end
-
-        specify { expect(evaluated_code).to eq(expected_evaluated_code) }
+      let(:expected_evaluated_code) do
+        <<~RUBY
+          a = 1
+          b = 2
+          a + b
+          # => 3
+        RUBY
       end
 
-      context 'when the `code` prints multiple things via `puts`' do
-        let(:code) do
-          <<~RUBY
-            puts('Hello testing world!')
-            puts('Hello again!')
-            ###
-          RUBY
-        end
+      specify { expect(evaluated_code).to eq(expected_evaluated_code) }
 
-        let(:expected_evaluated_code) do
-          <<~RUBY
-            puts('Hello testing world!')
-            puts('Hello again!')
-            # => prints "Hello testing world!", "Hello again!"
-          RUBY
-        end
-
-        specify { expect(evaluated_code).to eq(expected_evaluated_code) }
+      it 'does not modify the original code string/object' do
+        expect(code).to include('###')
       end
+    end
+
+    context 'when there are multiple code segments marked for evaluation' do
+      let(:code) do
+        <<~RUBY
+          1 + 2
+          ###
+
+          4 / 0
+          ###
+
+          99 - 66
+          ###
+        RUBY
+      end
+
+      let(:expected_evaluated_code) do
+        <<~RUBY
+          1 + 2
+          # => 3
+
+          4 / 0
+          # => raises ZeroDivisionError
+
+          99 - 66
+          # => 33
+        RUBY
+      end
+
+      it 'evaluates them all' do
+        expect(evaluated_code).to eq(expected_evaluated_code)
+      end
+    end
+
+    context 'when the `code` has a `# =>` evaluation marker' do
+      let(:code) do
+        <<~RUBY
+          a = 2
+          b = 3
+          a + b
+          # => 3
+        RUBY
+      end
+
+      let(:expected_evaluated_code) do
+        <<~RUBY
+          a = 2
+          b = 3
+          a + b
+          # => 5
+        RUBY
+      end
+
+      specify { expect(evaluated_code).to eq(expected_evaluated_code) }
+    end
+
+    context 'when the code raises an error' do
+      let(:code) do
+        <<~RUBY
+          3 / 0
+          ###
+        RUBY
+      end
+
+      let(:expected_evaluated_code) do
+        <<~RUBY
+          3 / 0
+          # => raises ZeroDivisionError
+        RUBY
+      end
+
+      specify { expect(evaluated_code).to eq(expected_evaluated_code) }
+    end
+
+    context 'when the `code` prints something via `puts`' do
+      let(:code) do
+        <<~RUBY
+          puts('Hello testing world!')
+          ###
+        RUBY
+      end
+
+      let(:expected_evaluated_code) do
+        <<~RUBY
+          puts('Hello testing world!')
+          # => prints "Hello testing world!"
+        RUBY
+      end
+
+      specify { expect(evaluated_code).to eq(expected_evaluated_code) }
+    end
+
+    context 'when the `code` prints multiple things via `puts`' do
+      let(:code) do
+        <<~RUBY
+          puts('Hello testing world!')
+          puts('Hello again!')
+          ###
+        RUBY
+      end
+
+      let(:expected_evaluated_code) do
+        <<~RUBY
+          puts('Hello testing world!')
+          puts('Hello again!')
+          # => prints "Hello testing world!", "Hello again!"
+        RUBY
+      end
+
+      specify { expect(evaluated_code).to eq(expected_evaluated_code) }
+    end
+
+    context 'when the `code` prints something via `puts` from within an object' do
+      let(:code) do
+        <<~RUBY
+          class Dog
+            def bark
+              puts('Woof!')
+            end
+          end
+          Dog.new.bark
+          ###
+        RUBY
+      end
+
+      let(:expected_evaluated_code) do
+        <<~RUBY
+          class Dog
+            def bark
+              puts('Woof!')
+            end
+          end
+          Dog.new.bark
+          # => prints "Woof!"
+        RUBY
+      end
+
+      specify { expect(evaluated_code).to eq(expected_evaluated_code) }
     end
   end
 end

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -15,10 +15,6 @@
         </h2>
         <div id="frontmatter" class="collapsible bordered p-6" contenteditable="true"
 >require 'yaml'
-
-def puts(printed_value)
-  $printed_objects << printed_value
-end
 </div>
       </div>
       <div class="p-3">


### PR DESCRIPTION
One downside of this is that now the user cannot use `puts` to actually see output for debugging purposes. I guess if our `puts` monkeypatch is working correctly, though, they can print the output in their code via a `###` marker, so maybe that's not so bad.