### PR TITLE
Require `stringio`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-[no unreleased changes yet]
+### Fixed
+- Fix "uninitialized constant StringIO" error when running `livdoc` executable
 
 ## v0.5.0 (2021-02-06)
 ### Added

--- a/lib/living_document.rb
+++ b/lib/living_document.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/string/filters' # for `#squish`
 require 'memoist'
+# require 'stringio'
 
 module LivingDocument ; end
 


### PR DESCRIPTION
I guess the error that is fixed by this change wasn't caught by tests because RSpec (or some other library required when we run tests) probably requires `stringio`.