### PR TITLE
Inline reading of .ruby-version file in gemspec

### DIFF
--- a/living_document.gemspec
+++ b/living_document.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/davidrunger/living_document'
   spec.license       = 'MIT'
 
-  ruby_version = File.read('.ruby-version').rstrip
-  spec.required_ruby_version = Gem::Requirement.new(">= #{ruby_version}")
+  spec.required_ruby_version = ">= #{File.read('.ruby-version').rstrip}")
 
   spec.metadata['rubygems_mfa_required'] = 'true'
   spec.metadata['homepage_uri'] = spec.homepage

--- a/living_document.gemspec
+++ b/living_document.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/davidrunger/living_document'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = ">= #{File.read('.ruby-version').rstrip}")
+  spec.required_ruby_version = ">= #{File.read('.ruby-version').rstrip}"
 
   spec.metadata['rubygems_mfa_required'] = 'true'
   spec.metadata['homepage_uri'] = spec.homepage


### PR DESCRIPTION
This is my new standard way of doing it, and, by standardizing, we can set ourselves up for programmatic updates.