### PR TITLE
[gemspec] Remove upper bounds on versions for all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove upper bounds on versions for all dependencies.
 
 ## v0.7.0 (2024-06-28)
 - Enforce only major and minor parts of required Ruby version (loosening the required Ruby version from 3.3.3 to 3.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,11 @@ PATH
   remote: .
   specs:
     living_document (0.7.1.alpha)
-      activesupport (>= 6, < 8)
+      activesupport (>= 6)
       listen (~> 3.2)
-      memo_wise (>= 1.7, < 2)
+      memo_wise (>= 1.7)
       redcarpet (~> 3.5)
-      sinatra (>= 2.1, < 5.0)
+      sinatra (>= 2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/living_document.gemspec
+++ b/living_document.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  spec.add_dependency('activesupport', '>= 6', '< 8')
+  spec.add_dependency('activesupport', '>= 6')
   spec.add_dependency('listen', '~> 3.2')
-  spec.add_dependency('memo_wise', '>= 1.7', '< 2')
+  spec.add_dependency('memo_wise', '>= 1.7')
   spec.add_dependency('redcarpet', '~> 3.5')
-  spec.add_dependency('sinatra', '>= 2.1', '< 5.0')
+  spec.add_dependency('sinatra', '>= 2.1')
 end


### PR DESCRIPTION
Let's optimistically assume that all future versions will be compatible. We can add restrictions or roll out a fix if that turns out not to be the case.

The upside of this change is that we don't have to make changes to this gem's gemspec to accommodate newly released versions of its dependencies.