### PR TITLE
[gemfile] Remove rubocop version constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development, :test do
   gem 'amazing_print'
   gem 'pry-byebug'
   gem 'rake'
-  gem 'rubocop', '!= 1.61.0', require: false
+  gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rake', require: false
   gem 'runger_style', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ DEPENDENCIES
   pry-byebug
   rake
   rspec
-  rubocop (!= 1.61.0)
+  rubocop
   rubocop-performance
   rubocop-rake
   runger_release_assistant


### PR DESCRIPTION
I don't know why I added this (probably some good reason documented it the git history), but RuboCop is well past version 1.61.0 now, so this `!= 1.61.0` restriction isn't really doing anything useful, now, so let's remove it.