### PR TITLE
Remove upper bound on 'listen' dependency in gemspec [LD-8]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
   specs:
     living_document (0.8.1.alpha)
       activesupport (>= 6)
-      listen (~> 3.2)
+      listen (>= 3.2)
       memo_wise (>= 1.7)
 
 GEM

--- a/living_document.gemspec
+++ b/living_document.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
   spec.add_dependency('activesupport', '>= 6')
-  spec.add_dependency('listen', '~> 3.2')
+  spec.add_dependency('listen', '>= 3.2')
   spec.add_dependency('memo_wise', '>= 1.7')
 end


### PR DESCRIPTION
I like to do this to lower friction for both users and maintainers when newer versions of dependencies are released. If there are bugs caused by breaking changes, then we can deal with them after the fact. It's a tradeoff/risk, but it's a tradeoff that I like to make.