### PR TITLE
[readme] Illustrate how to use livdoc with a markdown document [LD-9]

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ Then, edit the file and save it again. You'll see that the `# => ` comments are 
 LivingDocument can also handle Markdown code, which is especially convenient when developing
 documentation with examples.
 
+To utilize this functionality, simply provide a markdown document as the target file for `livdoc`, e.g.:
+
+```
+$ livdoc README.md
+```
+
+**NOTE:** Only code blocks that begin with `\`\`\`rb` or `\`\`\`ruby` will be evaluated.
+
 For example, LivingDocument will turn this...
 
 ~~~markdown

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To use this functionality, simply provide a markdown document as the target file
 $ livdoc README.md
 ```
 
-**NOTE:** Only code blocks that begin with `\`\`\`rb` or `\`\`\`ruby` will be evaluated.
+**NOTE:** Only code blocks that begin with `` ```rb `` or `` ```ruby `` will be evaluated.
 
 For example, LivingDocument will turn this...
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Then, edit the file and save it again. You'll see that the `# => ` comments are 
 LivingDocument can also handle Markdown code, which is especially convenient when developing
 documentation with examples.
 
-To utilize this functionality, simply provide a markdown document as the target file for `livdoc`, e.g.:
+To use this functionality, simply provide a markdown document as the target file for `livdoc`, e.g.:
 
 ```
 $ livdoc README.md


### PR DESCRIPTION
Also, note that codeblocks must be marked with a language of `rb` or `ruby` in order to be evaluated.