### PR TITLE
Remove frontmatter-related code [LD-6]

### DIFF
--- a/exe/livdoc
+++ b/exe/livdoc
@@ -22,17 +22,15 @@ listener =
 
     puts('Running code...')
     code_in_file = File.read(file_path)
-    frontmatter = code_in_file[/\A.*############\n\n/m] || ''
     code_to_write =
       LivingDocument::DocumentEvaluator.new(
-        document: code_in_file.delete_prefix(frontmatter),
-        frontmatter:,
+        document: code_in_file,
       ).evaluated_document
 
     $printed_objects_last_run = []
     puts("Writing file! #{Time.now}")
     last_file_update = Time.now
-    File.write(file_path, "#{frontmatter}#{code_to_write}")
+    File.write(file_path, code_to_write)
   end
 
 listener.start

--- a/lib/living_document/code_evaluator.rb
+++ b/lib/living_document/code_evaluator.rb
@@ -3,9 +3,8 @@
 class LivingDocument::CodeEvaluator
   prepend MemoWise
 
-  def initialize(code:, frontmatter: nil)
+  def initialize(code:)
     @code = code.dup
-    @frontmatter = frontmatter
 
     @known_erroring_segment_indexes = []
     @random_seed = rand(1_000_000_000)
@@ -58,7 +57,7 @@ class LivingDocument::CodeEvaluator
   end
 
   def code_segments_to_eval(current_index)
-    [@frontmatter] + printed_code_segments_to_eval(current_index)
+    printed_code_segments_to_eval(current_index)
   end
 
   def code_to_eval(current_index)

--- a/lib/living_document/document_evaluator.rb
+++ b/lib/living_document/document_evaluator.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class LivingDocument::DocumentEvaluator
-  def initialize(document:, frontmatter: nil)
+  def initialize(document:)
     @document = document.dup
-    @frontmatter = frontmatter
   end
 
   def evaluated_document
@@ -14,7 +13,6 @@ class LivingDocument::DocumentEvaluator
         evaluated_ruby_code =
           LivingDocument::CodeEvaluator.new(
             code: ruby_code,
-            frontmatter: @frontmatter,
           ).evaluated_code
         @document[markdown_codeblock] =
           <<~EVALUATED_CODEBLOCK.rstrip
@@ -27,7 +25,6 @@ class LivingDocument::DocumentEvaluator
     else
       LivingDocument::CodeEvaluator.new(
         code: @document,
-        frontmatter: @frontmatter,
       ).evaluated_code
     end
   end

--- a/spec/living_document/code_evaluator_spec.rb
+++ b/spec/living_document/code_evaluator_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe LivingDocument::CodeEvaluator do
   subject(:code_evaluator) do
-    LivingDocument::CodeEvaluator.new(code:, frontmatter: '')
+    LivingDocument::CodeEvaluator.new(code:)
   end
 
   describe '#evaluated_code' do

--- a/spec/living_document/document_evaluator_spec.rb
+++ b/spec/living_document/document_evaluator_spec.rb
@@ -4,79 +4,75 @@ require 'spec_helper'
 
 RSpec.describe LivingDocument::DocumentEvaluator do
   subject(:document_evaluator) do
-    LivingDocument::DocumentEvaluator.new(document:, frontmatter:)
+    LivingDocument::DocumentEvaluator.new(document:)
   end
 
   describe '#evaluated_document' do
     subject(:evaluated_document) { document_evaluator.evaluated_document }
 
-    context 'when the `frontmatter` is an empty string' do
-      let(:frontmatter) { '' }
-
-      context 'when the `document` is just Ruby code' do
-        let(:document) do
-          <<~RUBY
-            2 ** 5
-            ###
-          RUBY
-        end
-
-        let(:expected_evaluated_document) do
-          <<~RUBY
-            2 ** 5
-            # => 32
-          RUBY
-        end
-
-        specify { expect(evaluated_document).to eq(expected_evaluated_document) }
-
-        it 'does not modify the original document string/object' do
-          expect(document).to include('###')
-        end
+    context 'when the `document` is just Ruby code' do
+      let(:document) do
+        <<~RUBY
+          2 ** 5
+          ###
+        RUBY
       end
 
-      context 'when the `document` is markdown containing Ruby codeblocks' do
-        let(:document) do
-          <<~MARKDOWN
-            This is how you do addition in Ruby:
+      let(:expected_evaluated_document) do
+        <<~RUBY
+          2 ** 5
+          # => 32
+        RUBY
+      end
 
-            ```rb
-            2 + 3
-            ###
-            ```
+      specify { expect(evaluated_document).to eq(expected_evaluated_document) }
 
-            This is how you do exponentiation in Ruby:
+      it 'does not modify the original document string/object' do
+        expect(document).to include('###')
+      end
+    end
 
-            ```ruby
-            2 ** 4
-            ###
-            ```
-          MARKDOWN
-        end
+    context 'when the `document` is markdown containing Ruby codeblocks' do
+      let(:document) do
+        <<~MARKDOWN
+          This is how you do addition in Ruby:
 
-        let(:expected_evaluated_document) do
-          <<~MARKDOWN
-            This is how you do addition in Ruby:
+          ```rb
+          2 + 3
+          ###
+          ```
 
-            ```rb
-            2 + 3
-            # => 5
-            ```
+          This is how you do exponentiation in Ruby:
 
-            This is how you do exponentiation in Ruby:
+          ```ruby
+          2 ** 4
+          ###
+          ```
+        MARKDOWN
+      end
 
-            ```ruby
-            2 ** 4
-            # => 16
-            ```
-          MARKDOWN
-        end
+      let(:expected_evaluated_document) do
+        <<~MARKDOWN
+          This is how you do addition in Ruby:
 
-        specify { expect(evaluated_document).to eq(expected_evaluated_document) }
+          ```rb
+          2 + 3
+          # => 5
+          ```
 
-        it 'does not modify the original document string/object' do
-          expect(document).to include('###')
-        end
+          This is how you do exponentiation in Ruby:
+
+          ```ruby
+          2 ** 4
+          # => 16
+          ```
+        MARKDOWN
+      end
+
+      specify { expect(evaluated_document).to eq(expected_evaluated_document) }
+
+      it 'does not modify the original document string/object' do
+        expect(document).to include('###')
       end
     end
   end


### PR DESCRIPTION
This was something that we needed before in order to support capturing `puts` output. Instead, though, now we monkeypatch puts in the gem, rather than requiring the user to add it as frontmatter. See this diff: https://github.com/davidrunger/living_document/commit/faa9afbe#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5 .

The web app also used the "frontmatter" concept/code, but the web app was removed in https://github.com/davidrunger/living_document/pull/592 .

Therefore, we do not get value from this "frontmatter" stuff anymore, and so this change removes it.