### PR TITLE
Support -h/--help and -v/--version CLI flags [LD-13]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Support `-h`/`--help` and `-v`/`--version` CLI flags.
 
 ## v1.0.0 (2025-01-29)
 - **BREAKING:** Remove web server functionality.

--- a/exe/livdoc
+++ b/exe/livdoc
@@ -3,8 +3,16 @@
 # frozen_string_literal: true
 
 require 'listen'
+require 'optparse'
 
 require_relative '../lib/living_document.rb'
+
+parser = OptionParser.new
+parser.on('-v', '--version', 'Print the version') do
+  puts(LivingDocument::VERSION)
+  exit(0)
+end
+parser.parse!
 
 # rubocop:disable Style/TopLevelMethodDefinition
 def evaluate_code_and_update_source_file(file_path)


### PR DESCRIPTION
Note that -h/--help are not specified explicitly here, but rather are provided automatically by OptionParser.