### PR TITLE
Change test from symbol to string in Bundler.require call

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ SimpleCov.start do
 end
 
 require 'bundler/setup'
-Bundler.require(:default, 'test')
+Bundler.require(:default, :test)
 
 require 'living_document'
 


### PR DESCRIPTION
No major reason. Consistency. Symbols are better.