### PR TITLE
Support listening to files outside of the current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Support listening to files outside of the current directory.
 
 ## v1.1.1 (2025-01-30)
 - Fix exception when evaluating an empty target file. https://github.com/davidrunger/living_document/pull/608

--- a/exe/livdoc
+++ b/exe/livdoc
@@ -37,8 +37,15 @@ if file_path.nil?
 end
 
 last_file_update = Time.now
+
+expanded_file_path = File.expand_path(file_path)
+file_name = File.basename(expanded_file_path)
+
 listener =
-  Listen.to(Dir.pwd, only: /\A#{Regexp.escape(file_path)}\z/) do |_modified, _added, _removed|
+  Listen.to(
+    File.dirname(expanded_file_path),
+    only: /\A#{Regexp.escape(file_name)}\z/,
+  ) do |_modified, _added, _removed|
     # Don't enter infinitely recursive loop, since the code below triggers file updates.
     # After file has been updated, wait at least 0.5 seconds before listener processes again.
     next if (Time.now - last_file_update) < 0.5


### PR DESCRIPTION
This has two advantages:

1. It allows livdoc'ing a file that is outside of the current directory
2. It improves performance / lessens the burden on Listen by only listening to the smallest possible directory containing the file in question

Also, use `File.expand_path`. This will convert paths beginning with `~` (which Ruby cannot understand/read) to an expanded version using the user's raw home path, and other similar niceities to normalize whichever file path the user might have provided.

Also, update the `:only` regex option to reflect this new change. Apparently, the path string to match will be relative to the directory being watched, so we use `/\A#{Regexp.escape(file_name)}\z/`.