### PR TITLE
Use 'rb-inotify' (not 'listen') to watch for file changes [LD-16]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- **BREAKING:** Use `rb-inotify` (not `listen`) to watch for file changes. This means that the gem is now only compatible with Linux.
 - Support listening to files outside of the current directory.
 
 ## v1.1.1 (2025-01-30)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ PATH
   specs:
     living_document (1.1.2.alpha)
       activesupport (>= 6)
-      listen (>= 3.2)
       memo_wise (>= 1.7)
+      rb-inotify (>= 0.11.1)
       timecop (>= 0.9.10)
 
 GEM
@@ -63,9 +63,6 @@ GEM
       reline (>= 0.4.2)
     json (2.9.1)
     language_server-protocol (3.17.0.4)
-    listen (3.9.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.5)
     memo_wise (1.10.0)
     method_source (1.1.0)
@@ -87,7 +84,6 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
-    rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rdoc (6.11.0)
@@ -215,7 +211,6 @@ CHECKSUMS
   irb (1.15.1) sha256=d9bca745ac4207a8b728a52b98b766ca909b86ff1a504bcde3d6f8c84faae890
   json (2.9.1) sha256=d2bdef4644052fad91c1785d48263756fe32fcac08b96a20bb15840e96550d11
   language_server-protocol (3.17.0.4) sha256=c484626478664fd13482d8180947c50a8590484b1258b99b7aedb3b69df89669
-  listen (3.9.0) sha256=db9e4424e0e5834480385197c139cb6b0ae0ef28cc13310cfd1ca78377d59c67
   living_document (1.1.2.alpha)
   logger (1.6.5) sha256=c3cfe56d01656490ddd103d38b8993d73d86296adebc5f58cefc9ec03741e56b
   memo_wise (1.10.0) sha256=ae40ff8e7799697ff5d59d739b8766f76be22eba69c7c8468edb42ab83c94c3f
@@ -232,7 +227,6 @@ CHECKSUMS
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
-  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rdoc (6.11.0) sha256=bec66fb9b019be64f7ba7d2cd2aecb283a3a01fef23a95b33e2349c6d1aa0040
   regexp_parser (2.10.0) sha256=cb6f0ddde88772cd64bff1dbbf68df66d376043fe2e66a9ef77fcb1b0c548c61

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In other words, the special markers `###` and `# =>` tell LivingDocument to eval
 <!--ts-->
 * [LivingDocument](#livingdocument)
    * [Table of Contents](#table-of-contents)
+   * [Linux only <g-emoji class="g-emoji" alias="warning">⚠️</g-emoji>](#️-linux-only-️)
    * [Installation](#installation)
    * [Usage](#usage)
    * [Markdown support](#markdown-support)
@@ -45,9 +46,13 @@ In other words, the special markers `###` and `# =>` tell LivingDocument to eval
    * [License](#license)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: david, at: Wed Jan 29 07:45:21 PM CST 2025 -->
+<!-- Added by: david, at: Wed Feb  5 09:31:36 PM CST 2025 -->
 
 <!--te-->
+
+## ⚠️ Linux only ⚠️
+
+`living_document` relies on [`rb-inotify`](https://github.com/guard/rb-inotify), which provides efficient file system event notifications using the Linux inotify API. Since inotify is exclusive to the Linux kernel, the functionality provided by `rb-inotify` cannot be replicated on other operating systems. Since `living_document` relies on `rb-inotify` for efficient file system watching, `living_document` also only works on Linux.
 
 ## Installation
 

--- a/exe/livdoc
+++ b/exe/livdoc
@@ -2,8 +2,8 @@
 
 # frozen_string_literal: true
 
-require 'listen'
 require 'optparse'
+require 'rb-inotify'
 
 require_relative '../lib/living_document.rb'
 
@@ -15,17 +15,24 @@ end
 parser.parse!
 
 # rubocop:disable Style/TopLevelMethodDefinition
-def evaluate_code_and_update_source_file(file_path)
-  puts('Running code...')
+def evaluate_code_and_update_source_file(file_path, evaluation_reason:)
+  print("#{Time.now.iso8601} #{evaluation_reason} ... ")
+  # NOTE: This sleep seems to be necessary to interact reliably with VS Code.
+  sleep(0.015)
   code_in_file = File.read(file_path)
+
+  print('running code ... ')
   code_to_write =
     LivingDocument::DocumentEvaluator.new(
       document: code_in_file,
     ).evaluated_document
 
-  $printed_objects_last_run = []
-  puts("Writing file! #{Time.now}")
+  # NOTE: This sleep seems to be necessary to interact reliably with VS Code.
+  sleep(0.015)
+  print('writing file ... ')
   File.write(file_path, code_to_write)
+
+  puts('waiting for changes.')
 end
 # rubocop:enable Style/TopLevelMethodDefinition
 
@@ -36,34 +43,31 @@ if file_path.nil?
   exit(1)
 end
 
+expanded_path = File.expand_path(file_path)
+notifier = INotify::Notifier.new
 last_file_update = Time.now
 
-expanded_file_path = File.expand_path(file_path)
-file_name = File.basename(expanded_file_path)
+notifier.watch(expanded_path, :modify) do |_event|
+  # Don't enter infinitely recursive loop, since the code below triggers file updates.
+  # After file has been updated, wait at least 0.2 seconds before listener processes again.
+  next if (Time.now - last_file_update) < 0.2
 
-listener =
-  Listen.to(
-    File.dirname(expanded_file_path),
-    only: /\A#{Regexp.escape(file_name)}\z/,
-  ) do |_modified, _added, _removed|
-    # Don't enter infinitely recursive loop, since the code below triggers file updates.
-    # After file has been updated, wait at least 0.5 seconds before listener processes again.
-    next if (Time.now - last_file_update) < 0.5
+  evaluate_code_and_update_source_file(expanded_path, evaluation_reason: 'Detected file change')
 
-    evaluate_code_and_update_source_file(file_path)
-
-    last_file_update = Time.now
-  end
-
-listener.start
-system('clear')
-evaluate_code_and_update_source_file(file_path)
-puts('Waiting for file changes...')
+  last_file_update = Time.now
+end
 
 at_exit do
   print('Stopping listener ... ')
-  listener.stop
+  notifier.close
   puts('done.')
 end
 
-sleep
+system('clear')
+evaluate_code_and_update_source_file(expanded_path, evaluation_reason: 'Launching')
+
+begin
+  notifier.run
+rescue Interrupt
+  # Exit gracefully, having run `at_exit` block.
+end

--- a/lib/living_document.rb
+++ b/lib/living_document.rb
@@ -8,3 +8,5 @@ require 'timecop'
 module LivingDocument ; end
 
 Dir["#{File.dirname(__FILE__)}/living_document/**/*.rb"].each { |file| require file }
+
+LivingDocument.check_platform!

--- a/lib/living_document/platform_check.rb
+++ b/lib/living_document/platform_check.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module LivingDocument
+  def self.check_platform!
+    if !RUBY_PLATFORM.include?('linux')
+      raise('Sorry, but living_document only works on Linux')
+    end
+  end
+end

--- a/living_document.gemspec
+++ b/living_document.gemspec
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require_relative 'lib/living_document/platform_check'
 require_relative 'lib/living_document/version'
 
 Gem::Specification.new do |spec|
+  LivingDocument.check_platform!
+
   spec.name          = 'living_document'
   spec.version       = LivingDocument::VERSION
   spec.authors       = ['David Runger']
@@ -31,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
   spec.add_dependency('activesupport', '>= 6')
-  spec.add_dependency('listen', '>= 3.2')
   spec.add_dependency('memo_wise', '>= 1.7')
+  spec.add_dependency('rb-inotify', '>= 0.11.1')
   spec.add_dependency('timecop', '>= 0.9.10')
 end


### PR DESCRIPTION
`listen` is limited by the fact that it tries to expose a universal interface that works the same on all operating systems, and apparently MacOS doesn't have a performant/efficient way to watch a file that is at the top level of a directory with many other files (possibly in subdirectories), and so `listen` doesn't provide that functionality on any system.

`rb-inotify`, however, which I think is Linux-specific (and which `listen` depends upon), does have the ability to performantly watch a file that is in a directory that contains many other files (possibly in subdirectories).

Therefore, this change switches from using `listen` to using `rb-inotify`.

The upside is that `living_document` can now be performant on Linux machines in this scenario (where the file being watched is at the top level of a directory with many files). The downside, unfortunately, is that `living_document` will now only works on Linux.

This change also fixes various other little bugs that I noticed while working on this and makes various other little improvements.