### PR TITLE
Remove suggestion to go back to upstream pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gemspec
 group :development, :test do
   gem 'amazing_print'
   gem 'pry'
-  # Go back to upstream if/when https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 is merged.
   gem 'pry-byebug', github: 'davidrunger/pry-byebug'
   gem 'rake'
   gem 'rubocop', require: false


### PR DESCRIPTION
The mentioned PR ( https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 ) is not really the only advantage of using the `david_runger/pry-byebug` fork. Another advantage is that the fork uses `runger_byebug` rather than `byebug` (where `runger_byebug` has advantages, like this PR: https://github.com/davidrunger/runger_byebug/pull/10 ). Therefore, remove the suggestion to go back to the upstream `pry-byebug` after https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 has been merged (which it just was, although it hasn't yet been released via RubyGems).